### PR TITLE
Fix inverted mouse wheel direction under mouse reporting

### DIFF
--- a/jeditermfx-ui/src/main/java/com/techsenger/jeditermfx/ui/input/FxMouseWheelEvent.java
+++ b/jeditermfx-ui/src/main/java/com/techsenger/jeditermfx/ui/input/FxMouseWheelEvent.java
@@ -9,10 +9,14 @@ import com.techsenger.jeditermfx.core.emulator.mouse.MouseButtonModifierFlags;
 public final class FxMouseWheelEvent extends MouseWheelEvent {
 
     private static int createButtonCode(@NotNull ScrollEvent fxMouseEvent) {
-        if (fxMouseEvent.getDeltaY() > 0) {
+        // JavaFX deltaY > 0 means scrolling up, the opposite of AWT's getWheelRotation() > 0
+        double deltaY = fxMouseEvent.getDeltaY();
+        if (deltaY > 0) {
+            return MouseButtonCodes.SCROLLDOWN;
+        } else if (deltaY < 0) {
             return MouseButtonCodes.SCROLLUP;
         } else {
-            return MouseButtonCodes.SCROLLDOWN;
+            return MouseButtonCodes.NONE; // Ignore deltaY=0 events
         }
     }
 


### PR DESCRIPTION
Fixes #24.

When mouse reporting is active (e.g. attached to tmux with `mouse on`), the reported wheel direction is inverted: AWT's `getWheelRotation() > 0` means scrolling **down**, while JavaFX's `getDeltaY() > 0` means scrolling **up**. `FxMouseWheelEvent.createButtonCode` kept the AWT condition from JediTerm's `AwtMouseEvent` (`rotation > 0 → SCROLLUP`), so with `JediTerminal.mousePressed` encoding wheel buttons as `(code - 4) | 64`, a physical wheel-up was sent as xterm wheel-down (65) and vice versa.

This swaps the branches (`deltaY > 0 → SCROLLDOWN` = xterm 64 = wheel-up) and, matching JediTerm's `rotation == 0` handling, returns `NONE` for `deltaY == 0` so those events are ignored instead of being reported as a scroll.

The inverted behavior was observed with 1.1.0 on Windows (JediTermFX pane on a pty4j `ssh -t` + tmux `mouse on` session — scrollback moved opposite to the wheel); issue #24 has the full analysis. An equivalent sign flip applied as an application-side event filter restores the expected direction; I have not run a full build of this repo beyond `mvn -pl jeditermfx-ui -am compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
